### PR TITLE
Fix error on loading other languages

### DIFF
--- a/cron_descriptor/GetText.py
+++ b/cron_descriptor/GetText.py
@@ -30,7 +30,8 @@ class GetText(object):
         """
         code, encoding = locale.getlocale()
         try:
-            filename = os.path.join('locale', '{}.mo'.format(code))
+            filename = os.path.join(os.path.abspath(__file__),
+                                    'locale', '{}.mo'.format(code))
             trans = gettext.GNUTranslations(open(filename, "rb"))
             logging.debug('{} Loaded'.format(filename))
         except IOError:

--- a/examples/crontabReader.py
+++ b/examples/crontabReader.py
@@ -49,4 +49,5 @@ class CrontabReader(object):
 
         return None
 
+
 CrontabReader('/etc/crontab')


### PR DESCRIPTION
When use other languages, cron-descriptor is not able to locate mo files.

Added absolute path to fix it.