### PR TITLE
Tell PyPI the long_description is markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
         author_email="adam.schubert@sg1-game.net",
         url="https://github.com/Salamek/cron-descriptor",
         long_description=long_description,
+        long_description_content_type='text/markdown',
         packages=setuptools.find_packages(),
         package_data={
             'cron_descriptor': [


### PR DESCRIPTION
As per [packaging tutorial](https://packaging.python.org/guides/making-a-pypi-friendly-readme/) (see bottom). This should render it as markdown on https://pypi.org/project/cron_descriptor/ the next time you release.