### PR TITLE
Removed tests package from installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         url="https://github.com/Salamek/cron-descriptor",
         long_description=long_description,
         long_description_content_type='text/markdown',
-        packages=setuptools.find_packages(),
+        packages=setuptools.find_packages(exclude=['tests*',]),
         package_data={
             'cron_descriptor': [
                 'locale/*.mo',


### PR DESCRIPTION
This is fairly standard, and in fact some build system with fail builds that try to install tests packages.
Fixes #23 and makes setup.py compatible with Gentoo ebuilds.