### PR TITLE
Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Python library that converts cron expressions into human readable strings. Por
  * Supports 5, 6 (w/ seconds or year), or 7 (w/ seconds and year) part cron expressions
  * Provides casing options (Sentence, Title, Lower, etc.)
  * Localization with support for 14 languages
- * Supports Python 2.7 - 3.5
+ * Supports Python 2.7 - 3.6
 
 ## Installation
 Using PIP

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.3",
             "Programming Language :: Python :: 3.4",
             "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: 3.6",
             "Topic :: Software Development",
         ],
         test_suite="tests"


### PR DESCRIPTION
Looks like the CI is already testing and passing for Python 3.6. It seems the package should officially be good for python 3.6?
Updated the setup.py and README for official python 3.6 support.
For #25 