### PR TITLE
Fix typo on GetText IOError exception

### DIFF
--- a/cron_descriptor/ExpressionParser.py
+++ b/cron_descriptor/ExpressionParser.py
@@ -113,11 +113,6 @@ class ExpressionParser(object):
 
         return parsed
 
-    """
-
-    @param:
-    """
-
     def normalize_expression(self, expression_parts):
         """Converts cron expression components into consistent, predictable formats.
         Args:

--- a/cron_descriptor/GetText.py
+++ b/cron_descriptor/GetText.py
@@ -45,7 +45,7 @@ class GetText(object):
             trans = gettext.GNUTranslations(open(filename, "rb"))
             logger.debug('{} Loaded'.format(filename))
         except IOError:
-            logger.debug('Failed to found locale {}'.format(locale_code))
+            logger.debug('Failed to find locale {}'.format(locale_code))
             trans = gettext.NullTranslations()
 
         trans.install()


### PR DESCRIPTION
Issue found: when a locale is not setup, it logs `Failed to found locale`. This should instead be `Failed to find locale`.

Also, I removed empty comments above `ExpressionParser.normalize_expression`, as it doesn't seem they're needed.

EDIT: Ironic typo in my typo PR.