### PR TITLE
Add Korean support

### DIFF
--- a/cron_descriptor/locale/ko_KR.po
+++ b/cron_descriptor/locale/ko_KR.po
@@ -1,0 +1,218 @@
+# Translation of cron_descriptor
+# Copyright (C) 2016
+# This file is distributed under the same license as the cron_descriptor package.
+# Adam Schubert <adam.schubert@sg1-game.net>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.0\n"
+"Report-Msgid-Bugs-To: adam.schubert@sg1-game.net\n"
+"POT-Creation-Date: 2016-01-19 02:00+0100\n"
+"PO-Revision-Date: 2020-11-13 02:37+0900\n"
+"Last-Translator: Adam Schubert <adam.schubert@sg1-game.net>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 2.4.2\n"
+
+#: ExpressionDescriptor.py:130
+msgid ""
+"An error occured when generating the expression description.  Check the "
+"cron expression syntax."
+msgstr ""
+"크론표현식을 생성하는 도중 에러가 발생했습니다. 크론표현식 문법을 확인하세요."
+
+#: ExpressionDescriptor.py:151
+msgid "At "
+msgstr ""
+
+#: ExpressionDescriptor.py:160
+#, python-brace-format
+msgid "Every minute between {0} and {1}"
+msgstr "{0}부터 {1}까지 매분마다"
+
+#: ExpressionDescriptor.py:165
+msgid "At"
+msgstr ""
+
+#: ExpressionDescriptor.py:175
+msgid " and"
+msgstr " 그리고"
+
+#: ExpressionDescriptor.py:201
+msgid "every second"
+msgstr "매초마다"
+
+#: ExpressionDescriptor.py:201
+#, python-brace-format
+msgid "every {0} seconds"
+msgstr "매 {0}초마다"
+
+#: ExpressionDescriptor.py:201
+#, python-brace-format
+msgid "seconds {0} through {1} past the minute"
+msgstr "매분마다 {0}~{1}초 동안"
+
+#: ExpressionDescriptor.py:201
+#, python-brace-format
+msgid "at {0} seconds past the minute"
+msgstr "매분마다 {0}초에"
+
+#: ExpressionDescriptor.py:209
+msgid "every minute"
+msgstr "매분마다"
+
+#: ExpressionDescriptor.py:209
+#, python-brace-format
+msgid "every {0} minutes"
+msgstr "매 {0}분마다"
+
+#: ExpressionDescriptor.py:209
+#, python-brace-format
+msgid "minutes {0} through {1} past the hour"
+msgstr "매시간 {0}~{1}분 동안"
+
+#: ExpressionDescriptor.py:209
+#, python-brace-format
+msgid "at {0} minutes past the hour"
+msgstr "매시간 {0}분에"
+
+#: ExpressionDescriptor.py:218
+msgid "every hour"
+msgstr "매시마다"
+
+#: ExpressionDescriptor.py:218
+#, python-brace-format
+msgid "every {0} hours"
+msgstr "매 {0}시간마다"
+
+#: ExpressionDescriptor.py:218
+#, python-brace-format
+msgid "between {0} and {1}"
+msgstr "{0}부터 {1}까지"
+
+#: ExpressionDescriptor.py:218
+#, python-brace-format
+msgid "at {0}"
+msgstr "{0}"
+
+#: ExpressionDescriptor.py:241
+msgid "first"
+msgstr "첫째"
+
+#: ExpressionDescriptor.py:243
+msgid "second"
+msgstr "둘째"
+
+#: ExpressionDescriptor.py:245
+msgid "third"
+msgstr "셋째"
+
+#: ExpressionDescriptor.py:247
+msgid "forth"
+msgstr "넷째"
+
+#: ExpressionDescriptor.py:249
+msgid "fifth"
+msgstr "다섯째"
+
+#: ExpressionDescriptor.py:251
+msgid ", on the "
+msgstr ", "
+
+#: ExpressionDescriptor.py:252
+#, python-brace-format
+msgid " {0} of the month"
+msgstr " {0}"
+
+#: ExpressionDescriptor.py:254
+#, python-brace-format
+msgid ", on the last {0} of the month"
+msgstr ", 매월 마지막 {0} "
+
+#: ExpressionDescriptor.py:256
+#, python-brace-format
+msgid ", only on {0}"
+msgstr ", {0}에"
+
+#: ExpressionDescriptor.py:260 ExpressionDescriptor.py:303
+#: ExpressionDescriptor.py:435
+msgid ", every day"
+msgstr ", 매일"
+
+#: ExpressionDescriptor.py:260
+#, python-brace-format
+msgid ", every {0} days of the week"
+msgstr ", 매주 {0}일마다"
+
+#: ExpressionDescriptor.py:260 ExpressionDescriptor.py:274
+#: ExpressionDescriptor.py:318
+#, python-brace-format
+msgid ", {0} through {1}"
+msgstr ", {0}~{1}"
+
+#: ExpressionDescriptor.py:272
+#, python-brace-format
+msgid ", every {0} months"
+msgstr ", {0}개월마다"
+
+#: ExpressionDescriptor.py:275 ExpressionDescriptor.py:319
+#, python-brace-format
+msgid ", only in {0}"
+msgstr ", {0}"
+
+#: ExpressionDescriptor.py:288
+msgid ", on the last day of the month"
+msgstr ", 매월 마지막날"
+
+#: ExpressionDescriptor.py:290
+msgid ", on the last weekday of the month"
+msgstr ", 매월 마지막 평일"
+
+#: ExpressionDescriptor.py:297
+msgid "first weekday"
+msgstr "첫번째 평일"
+
+#: ExpressionDescriptor.py:297
+#, python-brace-format
+msgid "weekday nearest day {0}"
+msgstr "평일 가장 가까운 {0}번째 날"
+
+#: ExpressionDescriptor.py:299
+#, python-brace-format
+msgid ", on the {0} of the month"
+msgstr ", 매월 {0} "
+
+#: ExpressionDescriptor.py:303
+#, python-brace-format
+msgid ", every {0} days"
+msgstr ", {0}일마다"
+
+#: ExpressionDescriptor.py:304
+#, python-brace-format
+msgid ", between day {0} and {1} of the month"
+msgstr ", {0}부터 {1}일까지"
+
+#: ExpressionDescriptor.py:304
+#, python-brace-format
+msgid ", on day {0} of the month"
+msgstr ", 매월 {0}일"
+
+#: ExpressionDescriptor.py:316
+#, python-brace-format
+msgid ", every {0} years"
+msgstr ", {0}년마다"
+
+#: ExpressionDescriptor.py:385
+msgid " and "
+msgstr " 그리고 "
+
+#: ExpressionDescriptor.py:433
+msgid ", every minute"
+msgstr ", 매분마다"
+
+#: ExpressionDescriptor.py:434
+msgid ", every hour"
+msgstr ", 매시간마다"


### PR DESCRIPTION
In Korean, the order of words is quite different with latin languages. 
So it might not be perfect, but this changes will be enough to use.

It would be better if ExpressionDescriptor can determine the order of fields based on locale.

Any questions are welcomed. 
