### PR TITLE
Add possibility to use custom .mo files, locally

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pep8 flake8 pep8-naming
+        pip install mock pep8 flake8 pep8-naming
     - name: Test
       run: python setup.py test

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha - 3.11"]
+        python-version: ["2.7.18", "3.6.15", "3.7.15", "3.8.14", "3.9.15", "3.10.8", "3.11.0"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -6,10 +6,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # see https://github.com/actions/setup-python/issues/162#issuecomment-1325307787
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["2.7.18", "3.6.15", "3.7.15", "3.8.14", "3.9.15", "3.10.8", "3.11.0"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha - 3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/cron_descriptor/ExpressionDescriptor.py
+++ b/cron_descriptor/ExpressionDescriptor.py
@@ -71,7 +71,7 @@ class ExpressionDescriptor:
                 raise WrongArgumentException("Unknown {} configuration argument".format(kwarg))
 
         # Initializes localization
-        self.get_text = GetText(options.locale_code)
+        self.get_text = GetText(options.locale_code, options.locale_location)
 
     def _(self, message):
         return self.get_text.trans.gettext(message)

--- a/cron_descriptor/GetText.py
+++ b/cron_descriptor/GetText.py
@@ -39,13 +39,13 @@ class GetText(object):
     Handles language translations
     """
 
-    def __init__(self, locale_code):
+    def __init__(self, locale_code, locale_location=None):
         """
         Initialize GetText
         :param locale_code selected locale
         """
         try:
-            self.trans = self.load_locale(locale_code)
+            self.trans = self.load_locale(locale_code, locale_location)
         except IOError:
             logger.debug('Failed to find locale {}'.format(locale_code))
             logger.debug('Attempting to load en_US as fallback')
@@ -55,8 +55,11 @@ class GetText(object):
         # support for _("") or _("")
         self.trans.add_fallback(FallBackNull())
 
-    def load_locale(self, locale_code):
-        filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'locale', '{}.mo'.format(locale_code))
+    def load_locale(self, locale_code, locale_location=None):
+        if locale_location is None:
+            filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'locale', '{}.mo'.format(locale_code))
+        else:
+            filename = os.path.join(locale_location, '{}.mo'.format(locale_code))
         with open(filename, "rb") as f:
             trans = gettext.GNUTranslations(f)
         logger.debug('{} Loaded'.format(filename))

--- a/cron_descriptor/Options.py
+++ b/cron_descriptor/Options.py
@@ -37,6 +37,7 @@ class Options(object):
         self.verbose = False
         self.day_of_week_start_index_zero = True
         self.use_24hour_time_format = False
+        self.locale_location = None
 
         code, encoding = locale.getlocale()
         self.locale_code = code

--- a/tests/TestLocale.py
+++ b/tests/TestLocale.py
@@ -53,4 +53,4 @@ class TestLocale(TestCase.TestCase):
         options.use_24hour_time_format = True
         
         self.assertEqual("Jede Minute", ExpressionDescriptor("* * * * *", options).get_description())
-        logger.debug.assert_called_once_with(f'{temp_path} Loaded')
+        logger.debug.assert_called_once_with("{temp_path} Loaded".format(**{"temp_path":temp_path}))

--- a/tests/TestLocale.py
+++ b/tests/TestLocale.py
@@ -22,7 +22,7 @@
 
 import tests.TestCase as TestCase
 from cron_descriptor import Options, ExpressionDescriptor
-from unittest.mock import patch
+from mock import patch
 import tempfile, shutil, os
 import logging
 

--- a/tests/TestLocale.py
+++ b/tests/TestLocale.py
@@ -27,7 +27,6 @@ import tempfile, shutil, os
 import logging
 import glob 
 
-logger = logging.getLogger('cron_descriptor.GetText')
 
 class TestLocale(TestCase.TestCase):
 
@@ -39,18 +38,18 @@ class TestLocale(TestCase.TestCase):
             "Jede Minute",
             ExpressionDescriptor("* * * * *", options).get_description())
 
-    @patch.object(logger, "debug", MagicMock())
     def test_locale_de_custom_location(self):
+        logger = logging.getLogger('cron_descriptor.GetText')
+        with patch.object(logger, "debug") as mock_logger:
+            # Copy existing .mo file to temp directory:
+            temp_dir = tempfile.gettempdir()
+            temp_path = os.path.join(temp_dir, 'de_DE.mo')
+            shutil.copyfile(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../cron_descriptor/locale/', 'de_DE.mo'), temp_path)
 
-        # Copy existing .mo file to temp directory:
-        temp_dir = tempfile.gettempdir()
-        temp_path = os.path.join(temp_dir, 'de_DE.mo')
-        shutil.copyfile(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../cron_descriptor/locale/', 'de_DE.mo'), temp_path)
-
-        options = Options()
-        options.locale_location = temp_dir
-        options.locale_code = 'de_DE'
-        options.use_24hour_time_format = True
-        
-        self.assertEqual("Jede Minute", ExpressionDescriptor("* * * * *", options).get_description())
-        logger.debug.assert_called_once_with("{temp_path} Loaded".format(**{"temp_path":temp_path}))
+            options = Options()
+            options.locale_location = temp_dir
+            options.locale_code = 'de_DE'
+            options.use_24hour_time_format = True
+            
+            self.assertEqual("Jede Minute", ExpressionDescriptor("* * * * *", options).get_description())
+            mock_logger.assert_called_once_with("{temp_path} Loaded".format(**{"temp_path":temp_path}))

--- a/tests/TestLocale.py
+++ b/tests/TestLocale.py
@@ -22,10 +22,9 @@
 
 import tests.TestCase as TestCase
 from cron_descriptor import Options, ExpressionDescriptor
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import tempfile, shutil, os
 import logging
-import glob 
 
 
 class TestLocale(TestCase.TestCase):

--- a/tests/TestLocale.py
+++ b/tests/TestLocale.py
@@ -22,7 +22,12 @@
 
 import tests.TestCase as TestCase
 from cron_descriptor import Options, ExpressionDescriptor
+from unittest.mock import patch, MagicMock
+import tempfile, shutil, os
+import logging
+import glob 
 
+logger = logging.getLogger('cron_descriptor.GetText')
 
 class TestLocale(TestCase.TestCase):
 
@@ -33,3 +38,19 @@ class TestLocale(TestCase.TestCase):
         self.assertEqual(
             "Jede Minute",
             ExpressionDescriptor("* * * * *", options).get_description())
+
+    @patch.object(logger, "debug", MagicMock())
+    def test_locale_de_custom_location(self):
+
+        # Copy existing .mo file to temp directory:
+        temp_dir = tempfile.gettempdir()
+        temp_path = os.path.join(temp_dir, 'de_DE.mo')
+        shutil.copyfile(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../cron_descriptor/locale/', 'de_DE.mo'), temp_path)
+
+        options = Options()
+        options.locale_location = temp_dir
+        options.locale_code = 'de_DE'
+        options.use_24hour_time_format = True
+        
+        self.assertEqual("Jede Minute", ExpressionDescriptor("* * * * *", options).get_description())
+        logger.debug.assert_called_once_with(f'{temp_path} Loaded')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,8 @@ from tests.TestExceptions import TestExceptions
 from tests.TestFormats import TestFormats
 from tests.TestApi import TestApi
 from tests.TestImport import TestImport
+from tests.TestLocale import TestLocale
 
-__all__ = ['TestCasing', 'TestExceptions', 'TestFormats', 'TestApi', 'TestImport']
+__all__ = ['TestCasing', 'TestExceptions', 'TestFormats', 'TestApi', 'TestImport', 'TestLocale']
 __author__ = "Adam Schubert <adam.schubert@sg1-game.net>"
 __date__ = "$2016-01-17 14:51:02$"


### PR DESCRIPTION
I implemented a way to use an extra option, to search for .mo files in a custom directory.
This way people can generate their own translations and use them with this package. I guess there wasn't a way to do this before, at least the Options class didn't show any, so I implemented a way myself.