### PR TITLE
codespell: descriptor is properly formatted

### DIFF
--- a/cron_descriptor/ExpressionDescriptor.py
+++ b/cron_descriptor/ExpressionDescriptor.py
@@ -648,5 +648,5 @@ def get_description(expression, options=None):
         The cron expression description
 
     """
-    descripter = ExpressionDescriptor(expression, options)
-    return descripter.get_description(DescriptionTypeEnum.FULL)
+    descriptor = ExpressionDescriptor(expression, options)
+    return descriptor.get_description(DescriptionTypeEnum.FULL)

--- a/tests/TestExceptions.py
+++ b/tests/TestExceptions.py
@@ -27,7 +27,7 @@ from cron_descriptor import DescriptionTypeEnum, ExpressionDescriptor, MissingFi
 class TestExceptions(TestCase.TestCase):
 
     """
-    Tests that Exceptions are/not propery raised
+    Tests that Exceptions are/not properly raised
     """
 
     def test_none_cron_expression_exception(self):

--- a/tests/TestFormats.py
+++ b/tests/TestFormats.py
@@ -27,7 +27,7 @@ from cron_descriptor import get_description
 class TestFormats(TestCase.TestCase):
 
     """
-    Tests formated cron expressions
+    Tests formatted cron expressions
     """
 
     def test_every_minute(self):


### PR DESCRIPTION
% `codespell --skip="*.po" .`  https://pypi.org/project/codespell
```
./cron_descriptor/ExpressionDescriptor.py:651: descripter ==> descriptor
./cron_descriptor/ExpressionDescriptor.py:652: descripter ==> descriptor
./tests/TestExceptions.py:30: propery ==> property, properly
./tests/TestFormats.py:30: formated ==> formatted
```
% `codespell --skip="*.po" --write-changes .`